### PR TITLE
feat(rpc/testnet/etc/nginx/sites-available/default): add config to proxy pass wss requests to websocket endpoint

### DIFF
--- a/rpc/testnet/etc/nginx/sites-available/default
+++ b/rpc/testnet/etc/nginx/sites-available/default
@@ -131,6 +131,14 @@ server {
 		proxy_pass http://validator/ext/bc/2oo5UvYgFQikM7KBsMXFQE3RQv3xAFFc8JY2GEBNBF1tp4JaeZ/rpc;
 	}
 
+	location /ws {
+		proxy_pass http://validator/ext/bc/2oo5UvYgFQikM7KBsMXFQE3RQv3xAFFc8JY2GEBNBF1tp4JaeZ/ws;
+		proxy_http_version 1.1;
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection "Upgrade";
+		proxy_set_header Host $host;
+	}
+
 	# pass PHP scripts to FastCGI server
 	#
 	#location ~ \.php$ {


### PR DESCRIPTION
## Added
- Config to enable websocket requests to the RPC using the endpoint `https://<domain>/ws`

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202305127727547/1204676589440410) by [Unito](https://www.unito.io)
